### PR TITLE
add max_mjd option to CLI for loading spectra from DRP

### DIFF
--- a/src/astra/cli/astra.py
+++ b/src/astra/cli/astra.py
@@ -857,7 +857,7 @@ def migrate(
                 name="apogee_spectra",
                 func=migrate_apogee_spectra_from_sdss5_apogee_drpdb,
                 args=(apred,),
-                kwargs={"limit": limit, "incremental": incremental},
+                kwargs={"limit": limit, "incremental": incremental, "max_mjd": max_mjd},
                 description=f"Ingesting APOGEE {apred} spectra",
                 writes_to={"apogee_visit_spectrum"}
             )
@@ -875,7 +875,7 @@ def migrate(
             name="boss_spectra",
             func=migrate_from_spall_file,
             args=(run2d,),
-            kwargs={"limit": limit, "incremental": incremental},
+            kwargs={"limit": limit, "incremental": incremental, "max_mjd": max_mjd},
             description=f"Ingesting BOSS {run2d} spectra",
             writes_to={"boss_visit_spectrum"}
         )

--- a/src/astra/migrations/boss.py
+++ b/src/astra/migrations/boss.py
@@ -71,7 +71,7 @@ def match_unlinked_boss_visit_spectra():
     return n
 
 
-def migrate_from_spall_file(run2d, queue, gzip=True, limit=None, batch_size=10_000, incremental=True):
+def migrate_from_spall_file(run2d, queue, max_mjd: Optional[int] = None, gzip=True, limit=None, batch_size=10_000, incremental=True):
     """
     Migrate all new BOSS visit spectrum-level information from the spAll file, which is generated
     by the SDSS-V BOSS data reduction pipeline.
@@ -142,7 +142,10 @@ def migrate_from_spall_file(run2d, queue, gzip=True, limit=None, batch_size=10_0
             if most_recent is not None:
                 most_recent_mjd = most_recent.mjd
 
-        mask = spAll["MJD"] >= most_recent_mjd
+        if max_mjd is not None:
+            mask = (spAll["MJD"] >= most_recent_mjd) & (spAll["MJD"] <= max_mjd)
+        else:
+            mask = spAll["MJD"] >= most_recent_mjd
 
         if limit is not None:
             index = np.where(np.cumsum(mask) == limit)[0][0]


### PR DESCRIPTION
Currently the `max_mjd` option in the migration CLI is unused. I have passed these kwargs to the migration for the BOSS and APOGEE DRPs. This also required adding `max_mjd` to `migrate_from_spall_file` and adding it to the mask if not None.