### PR TITLE
ASPCAP Calibrations DR21

### DIFF
--- a/src/astra/pipelines/aspcap/corrections.py
+++ b/src/astra/pipelines/aspcap/corrections.py
@@ -1482,6 +1482,7 @@ def apply_ipl3_logg_corrections(batch_size: int = 500, limit: int = None):
 
     return None
 
+# ADD NEW FUNCTIONS #
 
 def apply_dr16_parameter_corrections(batch_size: int = 500):
     """


### PR DESCRIPTION
This will serve as the branch for adding in the `teff` and `logg` calibrations for ASPCAP to be used in DR21.

Corrections take place here: https://github.com/andycasey/astra/blob/0ac7e083da41cec8887361206028c5fd856050b9/src/astra/pipelines/aspcap/corrections.py#L1487

This demonstrates the structure of calling various correction functions for the different regions of the HR diagram. New ones will need to be added and called for the DR21 corrections: https://github.com/andycasey/astra/blob/0ac7e083da41cec8887361206028c5fd856050b9/src/astra/pipelines/aspcap/corrections.py#L1485

I also imagine the flags will need to be redefined: https://github.com/andycasey/astra/blob/0ac7e083da41cec8887361206028c5fd856050b9/src/astra/pipelines/aspcap/corrections.py#L57


Anything else I am missing here @andycasey ?