### PR TITLE
Major bugfix in astronn_dist

### DIFF
--- a/src/astra/pipelines/astronn_dist/base.py
+++ b/src/astra/pipelines/astronn_dist/base.py
@@ -98,7 +98,9 @@ def _inference(model, batch):
         except ValueError:
             raise
         else:
-            k_mag_cor = extinction_correction(all_meta[0][0], all_meta[0][2])
+            k_app = np.array([m[0] for m in all_meta])   # per-star apparent K magnitude
+            a_k = np.array([m[2] for m in all_meta])      # per-star A_K extinction
+            k_mag_cor = extinction_correction(k_app, a_k)
             #pc, pc_err = fakemag_to_pc(fakemag, k_mag_cor, fakemag_err['total']) # for the TensorFlow version
             pc, pc_err = fakemag_to_pc(fakemag, k_mag_cor, fakemag_err) # for the PyTorch version
 


### PR DESCRIPTION
In the parallel/batch code path of _inference, the fakemag->distance conversion used all_meta[0] (the first star in the batch) for every star, freezing star-0's apparent K magnitude across the whole batch. Since apparent magnitude dominates the distance, this destroyed the per-star distance signal (batch_size=100). Use per-star apparent K magnitude and A_K instead; extinction_correction and fakemag_to_pc are element-wise so this vectorizes cleanly.

^found and fixed by Claude, this shows what the before/after is.
<img width="1560" height="780" alt="image" src="https://github.com/user-attachments/assets/5553a991-461a-455e-acb9-f600a01ddba9" />
